### PR TITLE
Remove an absolutely completely unnecessary whitespace

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,6 @@ import streamlit as st
 import irc.client
 from llama_cpp import Llama
 
-
 @st.cache_resource
 def load_model(model_path):
     """Load a Llama model from a given path.


### PR DESCRIPTION
While I was trying to understand how this bot works, I was being constantly distracted by an unknown source of annoyance. I couldn't figure out if it was the lack of brackets, the weird comment syntax or the fact it was written in python.

After a few sleepless nights, I woke up in cold sweat at 3:35 in the morning and went to check the source code again. And I was right. It was revealed to me in a dream, that there was an occurrence of a mortal sin on line 8. 

To spare others of such fate, I hereby fix this error and provide you this PR.